### PR TITLE
wasmparser: add no_std support

### DIFF
--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -9,4 +9,8 @@ description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
 anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.82.0" }
+wasmparser = { path = "../wasmparser", version = "0.82.0", default-features = false, features = [] }
+
+[features]
+default = ["std"]
+std = ["wasmparser/std"]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -11,6 +11,9 @@ A simple event-driven library for parsing WebAssembly binary files.
 """
 edition = "2018"
 
+[dependencies]
+no-std-compat = { version = "0.4.1", default-features = false, features = ["compat_hash", "compat_sync", "alloc"] }
+
 [dev-dependencies]
 anyhow = "1.0"
 criterion = "0.3"
@@ -18,14 +21,24 @@ getopts = "0.2"
 wat = { path = "../wat" }
 wast = { path = "../wast" }
 rayon = "1.3"
-wasmparser-dump = { path = "../dump" }
+wasmparser-dump = { path = "../dump", default-features = false }
 
 [[bench]]
 name = "benchmark"
 harness = false
 
 [features]
+default = ["std"]
+# Enables the crate to use the Rust standard library.
+#
+# Disabling it allows to use the crate in environments without support
+# for the Rust standard library.
+#
+# Enabled by default.
+std = ["no-std-compat/std", "wasmparser-dump/std"]
 # The "deterministic" feature supports only Wasm code with "deterministic" execution
 # across any hardware. This feature is very critical for many Blockchain infrastructures
 # that rely on deterministic executions of smart contracts across different hardwares.
+#
+# Disabled by default.
 deterministic = []

--- a/crates/wasmparser/README.md
+++ b/crates/wasmparser/README.md
@@ -1,3 +1,9 @@
+> This is a fork of the `wasmparser` crate by the
+> [Bytecode Alliance](https://bytecodealliance.org/)
+> with the sole purpose to add `no_std` support.
+>
+> This crate will be deprecated as soon as `wasmparser` crate itself supports `no_std`.
+
 # The WebAssembly binary file decoder in Rust
 
 **A [Bytecode Alliance](https://bytecodealliance.org/) project**

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -15,6 +15,7 @@
 
 use std::convert::TryInto;
 use std::fmt;
+use std::prelude::v1::*;
 use std::str;
 
 use crate::limits::*;

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -23,6 +23,10 @@
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
 
+#![no_std]
+
+extern crate no_std_compat as std;
+
 pub use crate::binary_reader::BinaryReader;
 pub use crate::binary_reader::Range;
 

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -25,6 +25,7 @@
 use crate::limits::MAX_WASM_FUNCTION_LOCALS;
 use crate::primitives::{MemoryImmediate, Operator, SIMDLaneIndex, Type, TypeOrFuncType};
 use crate::{BinaryReaderError, Result, WasmFeatures, WasmFuncType, WasmModuleResources};
+use std::prelude::v1::*;
 
 /// A wrapper around a `BinaryReaderError` where the inner error's offset is a
 /// temporary placeholder value. This can be converted into a proper

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -7,6 +7,7 @@ use crate::{GlobalSectionReader, MemorySectionReader, TableSectionReader};
 use std::convert::TryInto;
 use std::fmt;
 use std::iter;
+use std::prelude::v1::*;
 
 /// An incremental parser of a binary WebAssembly module.
 ///

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -13,8 +13,11 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "std")]
 use std::error::Error;
+
 use std::fmt;
+use std::prelude::v1::*;
 use std::result;
 
 #[derive(Debug, Clone)]
@@ -34,6 +37,7 @@ pub(crate) struct BinaryReaderErrorInner {
 
 pub type Result<T, E = BinaryReaderError> = result::Result<T, E>;
 
+#[cfg(feature = "std")]
 impl Error for BinaryReaderError {}
 
 impl fmt::Display for BinaryReaderError {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -24,6 +24,7 @@ use crate::{FunctionBody, Parser, Payload};
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::sync::Arc;
+use std::prelude::v1::*;
 
 /// Test whether the given buffer contains a valid WebAssembly module,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -21,7 +21,7 @@ use crate::{BinaryReaderError, GlobalType, MemoryType, Range, Result, TableType,
 use crate::{DataKind, ElementItem, ElementKind, InitExpr, Instance, Operator};
 use crate::{FuncType, SectionReader, SectionWithLimitedItems};
 use crate::{FunctionBody, Parser, Payload};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
 use std::sync::Arc;
 use std::prelude::v1::*;
@@ -145,7 +145,7 @@ struct ModuleState {
     tags: Vec<usize>,            // pointer into `validator.types`
     submodules: Vec<usize>,      // pointer into `validator.types`
     instances: Vec<usize>,       // pointer into `validator.types`
-    function_references: HashSet<u32>,
+    function_references: BTreeSet<u32>,
 
     // This is populated when we hit the export section
     exports: NameSet,
@@ -267,14 +267,14 @@ impl TypeDef {
 struct ModuleType {
     imports_size: u32,
     exports_size: u32,
-    imports: HashMap<String, EntityType>,
-    exports: HashMap<String, EntityType>,
+    imports: BTreeMap<String, EntityType>,
+    exports: BTreeMap<String, EntityType>,
 }
 
 #[derive(Default)]
 struct InstanceType {
     type_size: u32,
-    exports: HashMap<String, EntityType>,
+    exports: BTreeMap<String, EntityType>,
 }
 
 #[derive(Clone)]
@@ -766,7 +766,7 @@ impl Validator {
         // Clear the list of implicit imports after the import section is
         // finished since later import sections cannot append further to the
         // pseudo-instances defined in this import section.
-        self.cur.state.assert_mut().imports.implicit.drain();
+        self.cur.state.assert_mut().imports.implicit.clear();
         Ok(())
     }
 
@@ -1118,8 +1118,8 @@ impl Validator {
 
     fn check_type_sets_match(
         &self,
-        a: &HashMap<String, EntityType>,
-        b: &HashMap<String, EntityType>,
+        a: &BTreeMap<String, EntityType>,
+        b: &BTreeMap<String, EntityType>,
         desc: &str,
     ) -> Result<()> {
         for (name, b) in b {
@@ -1831,8 +1831,8 @@ mod arc {
 /// single-level import of an instance, and that mapping happens here.
 #[derive(Default)]
 struct NameSet {
-    set: HashMap<String, EntityType>,
-    implicit: HashSet<String>,
+    set: BTreeMap<String, EntityType>,
+    implicit: BTreeSet<String>,
     type_size: u32,
 }
 


### PR DESCRIPTION
This also adds `no_std` support for `wasm-dump` since otherwise Cargo's feature resolver won't properly apply `no_std` to `wasmparser` within the `wasm-tools` Cargo workspace.