### PR TITLE
Add portable atomics support to unclock compilation on `thumbv6m-none-eabi` target.

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -14,6 +14,9 @@ exclude = ["benches/*.wasm"]
 
 [dependencies]
 indexmap = { version = "0.4.0", package = "indexmap-nostd", default-features = false }
+embedded-alloc = { version = "0.5", optional = true }
+portable-atomic-util = { version = "0.1.3", default-features = false, features = ["alloc"], optional = true }
+portable-atomic = { version = "1.3", default-features = false, features = ["require-cas", "critical-section"], optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -30,3 +33,4 @@ harness = false
 [features]
 default = ["std"]
 std = ["indexmap/std"]
+portable-atomics = ["embedded-alloc", "portable-atomic-util", "portable-atomic"]

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -14,7 +14,11 @@
  */
 
 use crate::{FuncType, GlobalType, MemoryType, TableType, ValType};
+#[cfg(not(feature = "portable-atomics"))]
+use ::alloc::sync::Arc;
 use ::core::ops::Range;
+#[cfg(feature = "portable-atomics")]
+use portable_atomic_util::Arc;
 
 /// Types that qualify as Wasm function types for validation purposes.
 pub trait WasmFuncType {
@@ -261,7 +265,7 @@ where
     }
 }
 
-impl<T> WasmModuleResources for ::alloc::sync::Arc<T>
+impl<T> WasmModuleResources for Arc<T>
 where
     T: WasmModuleResources,
 {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -17,10 +17,15 @@ use crate::{
     limits::*, BinaryReaderError, Encoding, FromReader, FunctionBody, Parser, Payload, Result,
     SectionLimited, ValType, WASM_COMPONENT_VERSION, WASM_MODULE_VERSION,
 };
+
+#[cfg(not(feature = "portable-atomics"))]
 use ::alloc::sync::Arc;
 use ::alloc::vec::Vec;
 use ::core::mem;
 use ::core::ops::Range;
+
+#[cfg(feature = "portable-atomics")]
+use portable_atomic_util::Arc;
 
 /// Test whether the given buffer contains a valid WebAssembly module or component,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -12,10 +12,15 @@ use crate::{
     Global, GlobalType, MemoryType, Result, TableType, TagType, TypeRef, ValType, VisitOperator,
     WasmFeatures, WasmModuleResources,
 };
+use ::alloc::collections::BTreeSet;
 use ::alloc::string::String;
 use ::alloc::string::ToString;
+#[cfg(not(feature = "portable-atomics"))]
+use ::alloc::sync::Arc;
 use ::alloc::vec::Vec;
-use ::alloc::{collections::BTreeSet, sync::Arc};
+#[cfg(feature = "portable-atomics")]
+use portable_atomic_util::Arc;
+
 use ::core::mem;
 use indexmap::IndexMap;
 
@@ -1065,8 +1070,12 @@ const _: () = {
 };
 
 mod arc {
+
+    #[cfg(not(feature = "portable-atomics"))]
     use ::alloc::sync::Arc;
     use ::core::ops::Deref;
+    #[cfg(feature = "portable-atomics")]
+    use portable_atomic_util::Arc;
 
     enum Inner<T> {
         Owned(T),

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -11,6 +11,8 @@ use ::alloc::collections::BTreeMap;
 use ::alloc::string::String as Url;
 use ::alloc::string::String;
 use ::alloc::string::ToString;
+
+#[cfg(not(feature = "portable-atomics"))]
 use ::alloc::sync::Arc;
 use ::alloc::vec::Vec;
 use ::core::{
@@ -21,6 +23,8 @@ use ::core::{
     ops::{Deref, DerefMut},
 };
 use indexmap::{IndexMap, IndexSet};
+#[cfg(feature = "portable-atomics")]
+use portable_atomic_util::Arc;
 
 /// The maximum number of parameters in the canonical ABI that can be passed by value.
 ///


### PR DESCRIPTION
This PR aims to solve one part of this issue,
- https://github.com/paritytech/wasmi/issues/738

You may read the full discussion there but it basically replaces `::alloc::sync::Arc` with `portable_atomic_util::Arc` in the `wasmparser` crate to unlock compilation for `thumbv6m-none-eabi`.

This behavior is under a feature flag `portable-atomics`.

This way `wasmparser` could be used with `RP2040` and other Arm Cortex M0 and M0+ targets.

You may test the compilation currently by running:
`cargo build --features portable-atomics --target thumbv6m-none-eabi -p wasmparser-nostd --no-default-features`

I have tested it in `v1.73.0-nightly`.